### PR TITLE
fix: [#9] wrap error in example

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -11,24 +11,23 @@ permissions:
   packages: read
 jobs:
   mcvs-golang-action:
-    # yamllint disable rule:braces
-    # yamllint disable rule:indentation
     strategy:
       matrix:
         args:
-          - { testing-type: "component" }
-          - { testing-type: "coverage" }
-          - { testing-type: "integration" }
-          - { testing-type: "lint", build-tags: "component" }
-          - { testing-type: "lint", build-tags: "e2e" }
-          - { testing-type: "lint", build-tags: "integration" }
-          - { testing-type: "security-golang-modules" }
-          - { testing-type: "security-grype" }
-          - { testing-type: "security-trivy" }
-          - { testing-type: "unit" }
-    runs-on: ubuntu-22.04
-    # yamllint enable rule:braces
-    # yamllint enable rule:indentation
+          - testing-type: "component"
+          - testing-type: "coverage"
+          - testing-type: "integration"
+          - testing-type: "lint"
+            build-tags: "component"
+          - testing-type: "lint"
+            build-tags: "e2e"
+          - testing-type: "lint"
+            build-tags: "integration"
+          - testing-type: "security-golang-modules"
+          - testing-type: "security-grype"
+          - testing-type: "security-trivy"
+          - testing-type: "unit"
+    runs-on: ubuntu-24.04
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,69 @@
+# yamllint disable rule:line-length
+---
+version: "2"
+linters:
+  default: all
+  disable:
+    # err113 is disabled as it does not make any sense to use wrapped static
+    # errors as it contains superfluous escaped double quotes.
+    - err113
+    # exhaustruct is disabled as there are scenarios in this code base where a
+    # some keys of a struct should be empty while testing.
+    - exhaustruct
+    # gochecknoglobals is disabled as there are global errors and component
+    # test variables.
+    - gochecknoglobals
+    # lll is disabled as there too many long lines in this project. Sometimes
+    # function names and struct names that are returned are combined too long,
+    # other times the error messages that are being checked are exceeding 120
+    # chars. To stop the leakage, all team members have been requested to
+    # set a ruler in vscode for go code to 120 chars.
+    - lll
+    - noctx
+    # testpackage is disabled as it is a bad practice to make methods public to
+    # be able to test them.
+    - testpackage
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - "!**/*_a _file.go"
+          allow:
+            - $gostd
+            - github.com/schubergphilis/mcvs-golang-project-root/pkg/projectroot
+            - github.com/sirupsen/logrus
+          deny:
+            - pkg: log
+              desc: Use 'log "github.com/sirupsen/logrus"' instead
+            - pkg: github.com/pkg/errors
+              desc: Should be replaced by standard lib errors package
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - internal/app/mcvs-scanner-cli/application/swagger
+      - third_party$
+      - builtin$
+      - examples$
+    rules:
+      - linters:
+          - funlen
+        path: _test\.go
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - internal/app/mcvs-scanner-cli/application/swagger
+      - third_party$
+      - builtin$
+      - examples$

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,10 +3,10 @@ version: 3
 
 vars:
   REMOTE_URL: https://raw.githubusercontent.com
-  REMOTE_URL_REF: v0.17.6
+  REMOTE_URL_REF: v2.0.0
   REMOTE_URL_REPO: schubergphilis/mcvs-golang-action
 
 includes:
   remote:
     taskfile: >-
-      {{.REMOTE_URL}}/{{.REMOTE_URL_REPO}}/{{.REMOTE_URL_REF}}/Taskfile.yml
+      {{.REMOTE_URL}}/{{.REMOTE_URL_REPO}}/{{.REMOTE_URL_REF}}/build/task.yml

--- a/examples/main.go
+++ b/examples/main.go
@@ -8,7 +8,8 @@ import (
 func main() {
 	projectRoot, err := projectroot.FindProjectRoot()
 	if err != nil {
-		log.WithFields(log.Fields{"err": err}).Fatal("unable to find project root")
+		log.WithError(err).Fatal("unable to find project root")
 	}
+
 	log.Infof("project root found at: %s", projectRoot)
 }

--- a/pkg/projectroot/projectroot.go
+++ b/pkg/projectroot/projectroot.go
@@ -1,6 +1,7 @@
 package projectroot
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +11,7 @@ import (
 func FindProjectRoot() (string, error) {
 	currentDir, err := os.Getwd()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to return path for the corresponding current working dir: %w", err)
 	}
 
 	for {
@@ -22,13 +23,15 @@ func FindProjectRoot() (string, error) {
 		if currentDir == parentDir {
 			break
 		}
+
 		currentDir = parentDir
 	}
 
-	return "", fmt.Errorf("project root not found")
+	return "", errors.New("project root not found")
 }
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
+
 	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
* Enable all linters except for a few that have been disabled with a documented rationale.
* Bump golang action ubuntu runner to latest stable, i.e. ubuntu-24.04.
* Address all linter issues.
* Modify the YAML structure in the Golang action workflow to allow the removal of yamllint suppressions.
* Update the path to the remote Taskfile to accommodate changes introduced in version 2.0.0.